### PR TITLE
Hdiutil additional options

### DIFF
--- a/lib/wrapp/cli.rb
+++ b/lib/wrapp/cli.rb
@@ -12,7 +12,7 @@ module Wrapp
 
     option :filesystem,
       :long => '--filesystem FILESYSTEM',
-      :short => '-fs FILESYSTEM',
+      :short => '-f FILESYSTEM',
       :description => "Causes a filesystem of the specified type to be written to the image.",
       :default => 'HFS+'
 

--- a/lib/wrapp/cli.rb
+++ b/lib/wrapp/cli.rb
@@ -10,6 +10,17 @@ module Wrapp
       :description => "Include the App's parent directory in the DMG with all(!!!) content.",
       :boolean => true
 
+    option :filesystem,
+      :long => '--filesystem FILESYSTEM',
+      :short => '-fs FILESYSTEM',
+      :description => "Causes a filesystem of the specified type to be written to the image.",
+      :default => 'HFS+'
+
+    option :volume_name,
+      :long => '--volume-name NAME',
+      :short => '-n NAME',
+      :description => "Volume name of the newly created filesystem."
+
     class << self
       def run
         new.run(ARGV)

--- a/lib/wrapp/dmg_builder.rb
+++ b/lib/wrapp/dmg_builder.rb
@@ -16,9 +16,10 @@ module Wrapp
       # to fail, see: https://discussions.apple.com/thread/5667409
       # Therefore we have to explicitely set the dmg size for bigger sources.
       cmd << "-megabytes #{dmg_size}" if big_source_folder?
-      cmd << "-volname #{vol_name}"
-      cmd << "-fs #{@opts[:filesyste]}"
+      cmd << "-volname '#{vol_name}'"
+      cmd << "-fs '#{@opts[:filesystem]}'"
       cmd << "'#{dmg_filename}'"
+
       system(cmd.join(' '))
     end
 
@@ -48,7 +49,8 @@ module Wrapp
     end
 
     def vol_name
-        @opts[:volume_name] ? @opts[:volume_name] : app.name
+      @opts[:volume_name] ? @opts[:volume_name] : app.name
+    end
 
     def app
       @app_info ||= AppInfo.new(plist)

--- a/lib/wrapp/dmg_builder.rb
+++ b/lib/wrapp/dmg_builder.rb
@@ -16,6 +16,8 @@ module Wrapp
       # to fail, see: https://discussions.apple.com/thread/5667409
       # Therefore we have to explicitely set the dmg size for bigger sources.
       cmd << "-megabytes #{dmg_size}" if big_source_folder?
+      cmd << "-volname #{vol_name}"
+      cmd << "-fs #{@opts[:filesyste]}"
       cmd << "'#{dmg_filename}'"
       system(cmd.join(' '))
     end
@@ -44,6 +46,9 @@ module Wrapp
     def dmg_filename
       "#{app.full_name}.dmg"
     end
+
+    def vol_name
+        @opts[:volume_name] ? @opts[:volume_name] : app.name
 
     def app
       @app_info ||= AppInfo.new(plist)

--- a/spec/wrapp/cli_spec.rb
+++ b/spec/wrapp/cli_spec.rb
@@ -62,6 +62,30 @@ module Wrapp
           end
         end
       end
+
+      %w(--filesystem -fs).each do |opt|
+        context "with #{opt}" do
+          let(:argv) { [app_path, opt] }
+
+          it 'specifies the filesystem type' do
+            cli.should_receive(:wrapp)
+              .with(app_path, :filesystem => 'HFS+')
+            cli.run(argv)
+          end
+        end
+      end
+
+      %w(--volume-name -n).each do |opt|
+        context "with #{opt}" do
+          let(:argv) { [app_path, opt] }
+
+          if 'specifies the volume name' do
+            cli.should_receive(:wrapp)
+              .with(app_path, :volume_name => '')
+            cli.run(argv)
+          end
+        end
+      end
     end
 
     describe '#wrapp' do

--- a/spec/wrapp/dmg_builder_spec.rb
+++ b/spec/wrapp/dmg_builder_spec.rb
@@ -100,6 +100,14 @@ module Wrapp
       end
     end
 
+    describe '#vol_name' do
+      if 'returns the volume name' do
+          app.should_receive(:name).and_return('chunky_bacon')
+          dmg.stub(:app).and_return(app)
+          expect(dmg.send(:vol_name)).to eq('chunky_bacon')
+      end
+    end
+
     describe '#app' do
       it 'creates a cached app_info instance' do
         dmg.should_receive(:plist).and_return('Info.plist')


### PR DESCRIPTION
Added 2 new options:
* ``--volume-name`` to specify the name of the DMG filesystem
* ``--filesystem`` to specify filesystem with ``HFS+`` default value

``--filesystem`` option is critical, because on High Sierra DMG created with ``APFS`` filesystem by default. But ``APFS`` is not supported on Sierra and earlier.